### PR TITLE
WID-88. Add possibility to open a widget for configuring a component

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,9 @@ notebook_shim>=0.1
 jinja2>=3.0.3
 y-py>=0.3.0,<0.4.0
 jupyterlab>=3.0.0,<4.0.0
+jupyterlab-widgets==1.1.0
 requests
 gitpython
 pygithub
 tqdm
+tvb-widgets

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ jinja2>=3.0.3
 y-py>=0.3.0,<0.4.0
 jupyterlab>=3.0.0,<4.0.0
 jupyterlab-widgets==1.1.0
+nbformat
 requests
 gitpython
 pygithub

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -50,7 +50,15 @@ export function addNodeActionCommands(
     commands.addCommand(commandIDs.openViewer, {
         execute: async (args) => {
             const node = selectedNode();
-            const dataToSend = { "model": "Generic2dOscillator" };
+            if (node.extras["has_widget"] === false) {
+                showDialog({
+                    title: `${node.name} does not have a widget assigned!`,
+                    buttons: [Dialog.warnButton({ label: 'OK' })]
+                })
+                return;
+            }
+
+            const dataToSend = { "component": node.name };
 
             const response = await requestAPI<any>('components/', {
 				body: JSON.stringify(dataToSend),

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -15,6 +15,7 @@ import { CommentDialog } from '../dialog/CommentDialog';
 import React from 'react';
 import { showFormDialog } from '../dialog/FormDialog';
 import { inputDialog } from '../dialog/LiteralInputDialog';
+import {requestAPI} from "../server/handler";
 
 /**
  * Add the commands for node actions.
@@ -44,6 +45,28 @@ export function addNodeActionCommands(
         selectedEntities.map((x) => node = x);
         return node ?? null;
     }
+
+    //Add command to open node's viewer in notebook
+    commands.addCommand(commandIDs.openViewer, {
+        execute: async (args) => {
+            const node = selectedNode();
+            const dataToSend = { "model": "Generic2dOscillator" };
+
+            const response = await requestAPI<any>('components/', {
+				body: JSON.stringify(dataToSend),
+				method: 'POST',
+			});
+
+            // Open node's file name
+            await app.commands.execute(
+                commandIDs.openDocManager,
+                {
+                    path: response["widget"],
+                    factory: 'Notebook',
+                    kernel: { name: 'python3' }
+                });
+        }
+    });
 
     //Add command to open node's script at specific line
     commands.addCommand(commandIDs.openScript, {

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -58,7 +58,7 @@ export function addNodeActionCommands(
                 return;
             }
 
-            const dataToSend = { "component": node.name };
+            const dataToSend = { "component": node.name, "path":  node.extras.path };
 
             const response = await requestAPI<any>('components/', {
 				body: JSON.stringify(dataToSend),

--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -94,6 +94,7 @@ export const commandIDs = {
 	runXircuit: 'Xircuit-editor:run-node',
 	debugXircuit: 'Xircuit-editor:debug-node',
 	lockXircuit: 'Xircuit-editor:lock-node',
+	openViewer: 'Xircuit-editor:open-node-viewer',
 	openScript: 'Xircuit-editor:open-node-script',
 	undo: 'Xircuit-editor:undo',
 	redo: 'Xircuit-editor:redo',

--- a/src/context-menu/NodeActionsPanel.tsx
+++ b/src/context-menu/NodeActionsPanel.tsx
@@ -58,6 +58,12 @@ export class NodeActionsPanel extends React.Component<NodeActionsPanelProps> {
 				</div>
 				<div className="option"
 					onClick={() => {
+						this.props.app.commands.execute(commandIDs.openViewer)
+					}}>
+					Open Viewer
+				</div>
+				<div className="option"
+					onClick={() => {
 						this.props.app.commands.execute(commandIDs.openScript)
 					}}>
 					Open Script

--- a/src/tray_library/AdvanceComponentLib.tsx
+++ b/src/tray_library/AdvanceComponentLib.tsx
@@ -32,7 +32,8 @@ export function AdvancedComponentLibrary(props: AdvancedComponentLibraryProps) {
             "type": nodeData.type,
             "path": nodeData.file_path,
             "description": nodeData.docstring,
-            "lineNo": nodeData.lineno
+            "lineNo": nodeData.lineno,
+            "has_widget": nodeData.has_widget
         }
     });
     node.addInPortEnhance('▶', 'in-0');

--- a/xai_components/base_tvb.py
+++ b/xai_components/base_tvb.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# "TheVirtualBrain - Widgets" package
+#
+# (c) 2022-2023, TVB Widgets Team
+#
+
+
+from xai_components.base import Component
+
+
+class ComponentWithWidget(Component):
+    """
+    Used to flag a component that has an associate widget to be displayed in Xircuits UI for interactive setup.
+    """
+
+    @property
+    def tvb_ht_class(self):
+        raise NotImplementedError

--- a/xai_components/xai_tvb/showcase1.py
+++ b/xai_components/xai_tvb/showcase1.py
@@ -19,11 +19,12 @@ from tvb.simulator.models.base import Model
 from tvb.simulator.noise import Noise
 from tvb.simulator.simulator import Simulator
 from xai_components.base import xai_component, Component, InArg, OutArg
+from xai_components.base_tvb import ComponentWithWidget
 from xai_components.xai_tvb.utils import print_component_summary
 
 
 @xai_component
-class MontbrioPazoRoxinModelComponent(Component):
+class MontbrioPazoRoxinModelComponent(ComponentWithWidget):
     eta: InArg[float]
     j: InArg[float]
     delta: InArg[float]
@@ -39,11 +40,13 @@ class MontbrioPazoRoxinModelComponent(Component):
         self.tau = InArg(None)
         self.model = OutArg(None)
 
-    def execute(self, ctx) -> None:
-        # imports
+    @property
+    def tvb_ht_class(self):
         from tvb.simulator.models.infinite_theta import MontbrioPazoRoxin
+        return MontbrioPazoRoxin
 
-        model = MontbrioPazoRoxin(
+    def execute(self, ctx) -> None:
+        model = self.tvb_ht_class(
             eta=np.r_[self.eta.value],
             J=np.r_[self.j.value],
             Delta=np.r_[self.delta.value],

--- a/xai_components/xai_tvb/simulator_code.py
+++ b/xai_components/xai_tvb/simulator_code.py
@@ -65,18 +65,14 @@ class LinearCouplingComponent(Component):
         print_component_summary(self.linear_coupling.value)
 
 
-class ModelComponent(Component):
-    code = """\
-            from tvbwidgets.api import PhasePlaneWidget
-            from tvb.simulator.lab import *
-            w = PhasePlaneWidget(model=models.Generic2dOscillator(),
-                                 integrator=integrators.HeunDeterministic());
-            from IPython.core.display_functions import display
-            display(w.get_widget());"""
+class ComponentWithWidget(Component):
+    """
+    Used to flag a component that has an associate widget to be displayed in Xircuits UI for interactive setup.
+    """
 
 
 @xai_component
-class Generic2dOscillatorComponent(ModelComponent):
+class Generic2dOscillatorComponent(ComponentWithWidget):
     model: OutArg[Generic2dOscillator]
 
     def __init__(self):

--- a/xai_components/xai_tvb/simulator_code.py
+++ b/xai_components/xai_tvb/simulator_code.py
@@ -65,8 +65,18 @@ class LinearCouplingComponent(Component):
         print_component_summary(self.linear_coupling.value)
 
 
+class ModelComponent(Component):
+    code = """\
+            from tvbwidgets.api import PhasePlaneWidget
+            from tvb.simulator.lab import *
+            w = PhasePlaneWidget(model=models.Generic2dOscillator(),
+                                 integrator=integrators.HeunDeterministic());
+            from IPython.core.display_functions import display
+            display(w.get_widget());"""
+
+
 @xai_component
-class Generic2dOscillatorComponent(Component):
+class Generic2dOscillatorComponent(ModelComponent):
     model: OutArg[Generic2dOscillator]
 
     def __init__(self):

--- a/xai_components/xai_tvb/simulator_code.py
+++ b/xai_components/xai_tvb/simulator_code.py
@@ -13,6 +13,7 @@ from tvb.simulator.models.oscillator import Generic2dOscillator
 from tvb.simulator.simulator import Simulator
 
 from xai_components.base import InArg, OutArg, Component, xai_component
+from xai_components.base_tvb import ComponentWithWidget
 from xai_components.xai_tvb.utils import print_component_summary
 
 
@@ -65,12 +66,6 @@ class LinearCouplingComponent(Component):
         print_component_summary(self.linear_coupling.value)
 
 
-class ComponentWithWidget(Component):
-    """
-    Used to flag a component that has an associate widget to be displayed in Xircuits UI for interactive setup.
-    """
-
-
 @xai_component
 class Generic2dOscillatorComponent(ComponentWithWidget):
     model: OutArg[Generic2dOscillator]
@@ -80,11 +75,13 @@ class Generic2dOscillatorComponent(ComponentWithWidget):
 
         self.model = OutArg(None)
 
-    def execute(self, ctx) -> None:
-        # imports
+    @property
+    def tvb_ht_class(self):
         from tvb.simulator.lab import models
+        return models.Generic2dOscillator
 
-        model = models.Generic2dOscillator()
+    def execute(self, ctx) -> None:
+        model = self.tvb_ht_class()
         self.model.value = model
         print_component_summary(self.model.value)
 

--- a/xircuits/handlers/components.py
+++ b/xircuits/handlers/components.py
@@ -10,7 +10,9 @@ import tornado
 from jupyter_server.base.handlers import APIHandler
 import platform
 
+from xai_components.xai_tvb.simulator_code import ModelComponent
 from .config import get_config
+from ..nb_generator import NotebookGenerator
 
 DEFAULT_COMPONENTS_PATHS = [
     os.path.join(os.path.dirname(__file__), "..", "..", "xai_components"),
@@ -159,29 +161,14 @@ class ComponentsRouteHandler(APIHandler):
         self.finish(json.dumps(data))
 
     def generate_phase_plane_notebook(self, model):
-        import nbformat as nbf
+        nb_generator = NotebookGenerator(DEFAULT_COMPONENTS_PATHS[0])
 
-        nb = nbf.v4.new_notebook()
-        text = """\
-        # My first automatic Jupyter Notebook
-        This is an auto-generated notebook."""
+        text = """# Dynamically generated NB!"""
+        nb_generator.add_markdown_cell(text)
+        nb_generator.add_code_cell(ModelComponent.code)
 
-        code = """\
-        from tvbwidgets.api import PhasePlaneWidget
-        from tvb.simulator.lab import *
-        w = PhasePlaneWidget(model=models.Generic2dOscillator(),
-                             integrator=integrators.HeunDeterministic());
-        from IPython.core.display_functions import display
-        display(w.get_widget());"""
-
-        nb['cells'] = [nbf.v4.new_markdown_cell(text),
-                       nbf.v4.new_code_cell(code)]
-        fname = os.path.join('xai_components', 'phase_plane_generated.ipynb')
-
-        with open(fname, 'w') as f:
-            nbf.write(nb, f)
-
-        return fname
+        path = nb_generator.store('phase_plane_generated.ipynb')
+        return path
 
     def get_component_directories(self):
         paths = list(DEFAULT_COMPONENTS_PATHS)

--- a/xircuits/handlers/components.py
+++ b/xircuits/handlers/components.py
@@ -142,7 +142,47 @@ class ComponentsRouteHandler(APIHandler):
                 "error_msg" : error_msg}
 
         self.finish(json.dumps(data))
-        
+
+    @tornado.web.authenticated
+    def post(self):
+        input_data = self.get_json_body()
+        model = None
+
+        try:
+            model = input_data["model"]
+        except:
+            pass
+
+        notebook_path = self.generate_phase_plane_notebook(model)
+        data = {"widget": notebook_path}
+
+        self.finish(json.dumps(data))
+
+    def generate_phase_plane_notebook(self, model):
+        import nbformat as nbf
+
+        nb = nbf.v4.new_notebook()
+        text = """\
+        # My first automatic Jupyter Notebook
+        This is an auto-generated notebook."""
+
+        code = """\
+        from tvbwidgets.api import PhasePlaneWidget
+        from tvb.simulator.lab import *
+        w = PhasePlaneWidget(model=models.Generic2dOscillator(),
+                             integrator=integrators.HeunDeterministic());
+        from IPython.core.display_functions import display
+        display(w.get_widget());"""
+
+        nb['cells'] = [nbf.v4.new_markdown_cell(text),
+                       nbf.v4.new_code_cell(code)]
+        fname = os.path.join('xai_components', 'phase_plane_generated.ipynb')
+
+        with open(fname, 'w') as f:
+            nbf.write(nb, f)
+
+        return fname
+
     def get_component_directories(self):
         paths = list(DEFAULT_COMPONENTS_PATHS)
         paths.append(get_config().get("DEV", "BASE_PATH"))
@@ -151,7 +191,7 @@ class ComponentsRouteHandler(APIHandler):
     def extract_components(self, file_path, base_dir, python_path):
         with open(file_path) as f:
             lines = f.readlines()
-        
+
         parse_tree = ast.parse(file_path.read_text(), file_path)
         # Look for top level class definitions that are decorated with "@xai_component"
         is_xai_component = lambda node: isinstance(node, ast.ClassDef) and \
@@ -175,7 +215,7 @@ class ComponentsRouteHandler(APIHandler):
         is_arg = lambda n: isinstance(n, ast.AnnAssign) and \
                                            isinstance(n.annotation, ast.Subscript) and \
                                            n.annotation.value.id in ('InArg', 'InCompArg', 'OutArg')
-        
+
         python_version = platform.python_version_tuple()
         if int(python_version[1]) == 8:
             variables = [

--- a/xircuits/handlers/components.py
+++ b/xircuits/handlers/components.py
@@ -10,9 +10,9 @@ import tornado
 from jupyter_server.base.handlers import APIHandler
 import platform
 
-from xai_components.xai_tvb.simulator_code import ModelComponent
 from .config import get_config
-from ..nb_generator import NotebookGenerator
+from xai_components.xai_tvb.simulator_code import ComponentWithWidget
+from xircuits.nb_generator import NotebookGenerator, WidgetCodeGenerator
 
 DEFAULT_COMPONENTS_PATHS = [
     os.path.join(os.path.dirname(__file__), "..", "..", "xai_components"),
@@ -68,12 +68,14 @@ COLOR_PALETTE = [
 GROUP_GENERAL = "GENERAL"
 GROUP_ADVANCED = "ADVANCED"
 
+
 def remove_prefix(input_str, prefix):
     prefix_len = len(prefix)
     if input_str[0:prefix_len] == prefix:
         return input_str[prefix_len:]
     else:
         return input_str
+
 
 def read_orig_code(node: ast.AST, lines):
     line_from = node.lineno - 1
@@ -90,6 +92,13 @@ def read_orig_code(node: ast.AST, lines):
         between_lines = lines[(line_from+1):line_to]
         end_line = lines[line_to][col_to]
         return "\n".join(chain([start_line], between_lines, [end_line]))
+
+
+def component_has_widget_assigned(node):
+    if any(base_class.id == ComponentWithWidget.__name__ for base_class in node.bases):
+        return True
+
+    return False
 
 
 class ComponentsRouteHandler(APIHandler):
@@ -141,33 +150,34 @@ class ComponentsRouteHandler(APIHandler):
                 c["color"] = COLOR_PALETTE[idx % len(COLOR_PALETTE)]
 
         data = {"components": components,
-                "error_msg" : error_msg}
+                "error_msg": error_msg}
 
         self.finish(json.dumps(data))
 
     @tornado.web.authenticated
     def post(self):
         input_data = self.get_json_body()
-        model = None
+        component = None
 
         try:
-            model = input_data["model"]
-        except:
-            pass
+            component = input_data["component"]
+        except KeyError:
+            data = {"error_msg": "Could not determine the component from POST params!"}
+            self.finish(json.dumps(data))
 
-        notebook_path = self.generate_phase_plane_notebook(model)
+        notebook_path = self.generate_widget_notebook(component)
         data = {"widget": notebook_path}
 
         self.finish(json.dumps(data))
 
-    def generate_phase_plane_notebook(self, model):
-        nb_generator = NotebookGenerator(DEFAULT_COMPONENTS_PATHS[0])
+    def generate_widget_notebook(self, component):
+        nb_generator = NotebookGenerator()
 
-        text = """# Dynamically generated NB!"""
+        text = f"""# Interactive setup for {component}"""
         nb_generator.add_markdown_cell(text)
-        nb_generator.add_code_cell(ModelComponent.code)
+        nb_generator.add_code_cell(WidgetCodeGenerator.get_widget_code(component))
 
-        path = nb_generator.store('phase_plane_generated.ipynb')
+        path = nb_generator.store(component)
         return path
 
     def get_component_directories(self):
@@ -232,6 +242,8 @@ class ComponentsRouteHandler(APIHandler):
             }
         ]
 
+        has_widget = component_has_widget_assigned(node)
+
         output = {
             "class": name,
             "package_name": ("xai_components." if python_path is None else "") + file_path.as_posix().replace("/", ".")[:-3],
@@ -244,7 +256,8 @@ class ComponentsRouteHandler(APIHandler):
             "type": "debug",
             "variables": variables,
             "docstring": docstring,
-            "lineno" : lineno
+            "lineno": lineno,
+            "has_widget": has_widget
         }
         output.update(keywords)
 

--- a/xircuits/handlers/components.py
+++ b/xircuits/handlers/components.py
@@ -161,21 +161,22 @@ class ComponentsRouteHandler(APIHandler):
 
         try:
             component = input_data["component"]
+            component_path = input_data["path"]
         except KeyError:
             data = {"error_msg": "Could not determine the component from POST params!"}
             self.finish(json.dumps(data))
 
-        notebook_path = self.generate_widget_notebook(component)
+        notebook_path = self.generate_widget_notebook(component, component_path)
         data = {"widget": notebook_path}
 
         self.finish(json.dumps(data))
 
-    def generate_widget_notebook(self, component):
+    def generate_widget_notebook(self, component, component_path):
         nb_generator = NotebookGenerator()
 
         text = f"""# Interactive setup for {component}"""
         nb_generator.add_markdown_cell(text)
-        nb_generator.add_code_cell(WidgetCodeGenerator.get_widget_code(component))
+        nb_generator.add_code_cell(WidgetCodeGenerator.get_widget_code(component, component_path))
 
         path = nb_generator.store(component)
         return path

--- a/xircuits/nb_generator.py
+++ b/xircuits/nb_generator.py
@@ -1,0 +1,32 @@
+import os
+import nbformat
+
+
+class NotebookGenerator(object):
+
+    def __init__(self, notebooks_dir=None):
+        if notebooks_dir is None:
+            notebooks_dir = 'generated_notebooks'
+
+        if not os.path.exists(notebooks_dir):
+            os.mkdir(notebooks_dir)
+
+        self.notebooks_dir = notebooks_dir
+        self.notebook = nbformat.v4.new_notebook()
+
+    def add_code_cell(self, code):
+        self._add_cell(nbformat.v4.new_code_cell(code))
+
+    def add_markdown_cell(self, text):
+        self._add_cell(nbformat.v4.new_markdown_cell(text))
+
+    def _add_cell(self, cell):
+        self.notebook['cells'].append(cell)
+
+    def store(self, file_name):
+        path = os.path.join(self.notebooks_dir, file_name)
+
+        with open(path, 'w') as f:
+            nbformat.write(self.notebook, f)
+
+        return path


### PR DESCRIPTION
This PR adds a new button in the component menu "Open Viewer" which triggers the backend to generate a jupyter notebook with the corresponding widget.
Still have some TODOs which I believe would be solved better after WID-95 is done.
Also, we want to link the resulting configuration (from the widget) with the Xircuits component in a separate task.