### PR TITLE
WID-135. Remove Xircuits logo from JupyterLab

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -117,27 +117,6 @@ const xircuits: JupyterFrontEndPlugin<void> = {
       }),
       name: widget => widget.context.path
     });
-    
-    // Find the MainLogo widget in the shell and replace it with the Xircuits Logo
-    const widgets = app.shell.widgets('top');
-    let widget = widgets.next();
-
-    while (widget !== undefined) {
-      if (widget.id === 'jp-MainLogo') {
-        xircuitsIcon.element({
-          container: widget.node,
-          justify: 'center',
-          height: 'auto',
-          width: '25px'
-        });
-        break;
-      }
-
-      widget = widgets.next();
-    }
-
-    // Change the favicon
-    changeFavicon(xircuitsFaviconLink);
 
     // Creating the sidebar widget for the xai components
     const sidebarWidget = ReactWidget.create(<Sidebar lab={app} factory={widgetFactory}/>);


### PR DESCRIPTION
After the review received from EBRAINS regarding the extension, it was requested to not replace the JupyterLab logo with the Xircuits logo (see [issue WID-135](https://req.thevirtualbrain.org/browse/WID-135) for more details). 
Besides removing the Xircuits logo from the JupyterLab area, it was also removed from the browser tab icon.