### PR TITLE
WID-142. Add  required inputs

### DIFF
--- a/xai_components/xai_tvb_monitors/monitors.py
+++ b/xai_components/xai_tvb_monitors/monitors.py
@@ -11,7 +11,7 @@ from tvb.datatypes.region_mapping import RegionMapping
 from tvb.datatypes.sensors import SensorsEEG, SensorsInternal, SensorsMEG
 from tvb.simulator.noise import Noise
 
-from xai_components.base import xai_component, Component, InArg, OutArg
+from xai_components.base import xai_component, Component, InArg, OutArg, InCompArg
 from xai_components.utils import print_component_summary, set_defaults, set_values
 
 
@@ -209,9 +209,9 @@ class EEG(Component):
     variables_of_interest: InArg[list]
     region_mapping: InArg[RegionMapping]
     obsnoise: InArg[Noise]
-    projection: InArg[ProjectionSurfaceEEG]
+    projection: InCompArg[ProjectionSurfaceEEG]
     reference: InArg[str]
-    sensors: InArg[SensorsEEG]
+    sensors: InCompArg[SensorsEEG]
     sigma: InArg[float]
 
     eEG: OutArg[list]
@@ -238,8 +238,8 @@ class MEG(Component):
     variables_of_interest: InArg[list]
     region_mapping: InArg[RegionMapping]
     obsnoise: InArg[Noise]
-    projection: InArg[ProjectionSurfaceMEG]
-    sensors: InArg[SensorsMEG]
+    projection: InCompArg[ProjectionSurfaceMEG]
+    sensors: InCompArg[SensorsMEG]
 
     mEG: OutArg[list]
 
@@ -265,9 +265,9 @@ class iEEG(Component):
     variables_of_interest: InArg[list]
     region_mapping: InArg[RegionMapping]
     obsnoise: InArg[Noise]
-    projection: InArg[ProjectionSurfaceSEEG]
+    projection: InCompArg[ProjectionSurfaceSEEG]
     sigma: InArg[float]
-    sensors: InArg[SensorsInternal]
+    sensors: InCompArg[SensorsInternal]
 
     iEEG: OutArg[list]
 

--- a/xai_components/xai_tvb_projections/projections.py
+++ b/xai_components/xai_tvb_projections/projections.py
@@ -1,7 +1,7 @@
 from tvb.datatypes.projections import ProjectionMatrix
 from tvb.datatypes.sensors import Sensors
 from tvb.datatypes.surfaces import Surface
-from xai_components.base import xai_component, InArg, OutArg, Component
+from xai_components.base import xai_component, InArg, OutArg, Component, InCompArg
 from xai_components.utils import print_component_summary
 
 
@@ -9,9 +9,8 @@ from xai_components.utils import print_component_summary
 class ProjectionSurfaceEEG(Component):
     from tvb.datatypes.projections import ProjectionSurfaceEEG
     file_path: InArg[str]
-    sources: InArg[Surface]
-    sensors: InArg[Sensors]
-    projection_data: InArg[list]
+    sources: InCompArg[Surface]
+    sensors: InCompArg[Sensors]
 
     projectionSurfaceEEG: OutArg[ProjectionMatrix]
 
@@ -24,9 +23,8 @@ class ProjectionSurfaceEEG(Component):
         self.done = False
 
         self.file_path = InArg(None)
-        self.sources = InArg(None)
-        self.sensors = InArg(None)
-        self.projection_data = InArg(None)
+        self.sources = InCompArg(None)
+        self.sensors = InCompArg(None)
         self.projectionSurfaceEEG = OutArg(None)
 
     def execute(self, ctx) -> None:
@@ -37,7 +35,6 @@ class ProjectionSurfaceEEG(Component):
 
         projectionSurfaceEEG.sources = self.sources.value
         projectionSurfaceEEG.sensors = self.sensors.value
-        projectionSurfaceEEG.projection_data = self.projection_data.value
         projectionSurfaceEEG.configure()
 
         self.projectionSurfaceEEG.value = projectionSurfaceEEG
@@ -47,9 +44,8 @@ class ProjectionSurfaceEEG(Component):
 @xai_component(color='rgb(67, 47, 106)')
 class ProjectionSurfaceMEG(Component):
     file_path: InArg[str]
-    sources: InArg[Surface]
-    sensors: InArg[Sensors]
-    projection_data: InArg[list]
+    sources: InCompArg[Surface]
+    sensors: InCompArg[Sensors]
 
     projectionSurfaceMEG: OutArg[ProjectionMatrix]
 
@@ -62,9 +58,8 @@ class ProjectionSurfaceMEG(Component):
         self.done = False
 
         self.file_path = InArg(None)
-        self.sources = InArg(None)
-        self.sensors = InArg(None)
-        self.projection_data = InArg(None)
+        self.sources = InCompArg(None)
+        self.sensors = InCompArg(None)
         self.projectionSurfaceMEG = OutArg(None)
 
     def execute(self, ctx) -> None:
@@ -75,7 +70,6 @@ class ProjectionSurfaceMEG(Component):
 
         projectionSurfaceMEG.sources = self.sources.value
         projectionSurfaceMEG.sensors = self.sensors.value
-        projectionSurfaceMEG.projection_data = self.projection_data.value
         projectionSurfaceMEG.configure()
 
         self.projectionSurfaceMEG.value = projectionSurfaceMEG
@@ -85,9 +79,8 @@ class ProjectionSurfaceMEG(Component):
 @xai_component(color='rgb(67, 47, 106)')
 class ProjectionSurfaceSEEG(Component):
     file_path: InArg[str]
-    sources: InArg[Surface]
-    sensors: InArg[Sensors]
-    projection_data: InArg[list]
+    sources: InCompArg[Surface]
+    sensors: InCompArg[Sensors]
 
     projectionSurfaceSEEG: OutArg[ProjectionMatrix]
 
@@ -100,9 +93,8 @@ class ProjectionSurfaceSEEG(Component):
         self.done = False
 
         self.file_path = InArg(None)
-        self.sources = InArg(None)
-        self.sensors = InArg(None)
-        self.projection_data = InArg(None)
+        self.sources = InCompArg(None)
+        self.sensors = InCompArg(None)
         self.projectionSurfaceSEEG = OutArg(None)
 
     def execute(self, ctx) -> None:
@@ -113,7 +105,6 @@ class ProjectionSurfaceSEEG(Component):
 
         projectionSurfaceSEEG.sources = self.sources.value
         projectionSurfaceSEEG.sensors = self.sensors.value
-        projectionSurfaceSEEG.projection_data = self.projection_data.value
         projectionSurfaceSEEG.configure()
 
         self.projectionSurfaceSEEG.value = projectionSurfaceSEEG

--- a/xai_components/xai_tvb_sensors/sensors.py
+++ b/xai_components/xai_tvb_sensors/sensors.py
@@ -8,11 +8,8 @@ from xai_components.utils import set_values, print_component_summary, set_defaul
 @xai_component(color='rgb(0, 116, 149)')
 class SensorsEEG(TVBComponent):
     file_path: InArg[str]
-    labels: InArg[list]
-    locations: InArg[list]
     has_orientation: InArg[bool]
     orientations: InArg[list]
-    number_of_sensors: InArg[int]
     usable: InArg[list]
 
     sensorsEEG: OutArg[Sensors]
@@ -41,11 +38,6 @@ class SensorsEEG(TVBComponent):
 @xai_component(color='rgb(0, 116, 149)')
 class SensorsMEG(TVBComponent):
     file_path: InArg[str]
-    labels: InArg[list]
-    locations: InArg[list]
-    has_orientation: InArg[bool]
-    orientations: InArg[list]
-    number_of_sensors: InArg[int]
     usable: InArg[list]
 
     sensorsMEG: OutArg[Sensors]
@@ -74,11 +66,8 @@ class SensorsMEG(TVBComponent):
 @xai_component(color='rgb(0, 116, 149)')
 class SensorsInternal(TVBComponent):
     file_path: InArg[str]
-    labels: InArg[list]
-    locations: InArg[list]
     has_orientation: InArg[bool]
     orientations: InArg[list]
-    number_of_sensors: InArg[int]
     usable: InArg[list]
 
     sensorsInternal: OutArg[Sensors]

--- a/xai_components/xai_tvb_simulator/simulator.py
+++ b/xai_components/xai_tvb_simulator/simulator.py
@@ -12,14 +12,14 @@ from tvb.simulator.coupling import Coupling
 from tvb.simulator.integrators import Integrator
 from tvb.simulator.models.base import Model
 
-from xai_components.base import InArg, OutArg, Component, xai_component
+from xai_components.base import InArg, OutArg, Component, xai_component, InCompArg
 from xai_components.utils import print_component_summary, set_defaults, set_values
 
 
 @xai_component(color='rgb(220, 5, 45)')
 class Simulator(Component):
     from tvb.simulator.simulator import Simulator
-    connectivity: InArg[Connectivity]
+    connectivity: InCompArg[Connectivity]
     conduction_speed: InArg[float]
     coupling: InArg[Coupling]
     surface: InArg[Cortex]

--- a/xai_components/xai_tvb_surfaces/surfaces.py
+++ b/xai_components/xai_tvb_surfaces/surfaces.py
@@ -1,6 +1,5 @@
 from tvb.datatypes.surfaces import Surface
-import scipy.sparse
-from xai_components.base import xai_component, InArg, OutArg
+from xai_components.base import xai_component, InArg, OutArg, InCompArg
 from xai_components.base_tvb import TVBComponent
 from xai_components.utils import set_values, print_component_summary, set_defaults
 
@@ -8,20 +7,9 @@ from xai_components.utils import set_values, print_component_summary, set_defaul
 @xai_component(color='rgb(0, 116, 92)')
 class WhiteMatterSurface(TVBComponent):
     file_path: InArg[str]
-    vertices: InArg[list]
-    triangles: InArg[list]
-    vertex_normals: InArg[list]
     triangle_normals: InArg[list]
-    geodesic_distance_matrix: InArg[scipy.sparse.csc_matrix]
-    number_of_vertices: InArg[int]
-    number_of_triangles: InArg[int]
-    edge_mean_length: InArg[float]
-    edge_min_length: InArg[float]
-    edge_max_length: InArg[float]
     hemisphere_mask: InArg[list]
-    zero_based_triangles: InArg[bool]
-    bi_hemispheric: InArg[bool]
-    valid_for_simulations: InArg[bool]
+    zero_based_triangles: InCompArg[bool]
 
     whiteMatterSurface: OutArg[Surface]
 
@@ -49,20 +37,9 @@ class WhiteMatterSurface(TVBComponent):
 @xai_component(color='rgb(0, 116, 92)')
 class CorticalSurface(TVBComponent):
     file_path: InArg[str]
-    vertices: InArg[list]
-    triangles: InArg[list]
-    vertex_normals: InArg[list]
     triangle_normals: InArg[list]
-    geodesic_distance_matrix: InArg[scipy.sparse.csc_matrix]
-    number_of_vertices: InArg[int]
-    number_of_triangles: InArg[int]
-    edge_mean_length: InArg[float]
-    edge_min_length: InArg[float]
-    edge_max_length: InArg[float]
     hemisphere_mask: InArg[list]
-    zero_based_triangles: InArg[bool]
-    bi_hemispheric: InArg[bool]
-    valid_for_simulations: InArg[bool]
+    zero_based_triangles: InCompArg[bool]
 
     corticalSurface: OutArg[Surface]
 
@@ -90,20 +67,9 @@ class CorticalSurface(TVBComponent):
 @xai_component(color='rgb(0, 116, 92)')
 class SkinAir(TVBComponent):
     file_path: InArg[str]
-    vertices: InArg[list]
-    triangles: InArg[list]
-    vertex_normals: InArg[list]
     triangle_normals: InArg[list]
-    geodesic_distance_matrix: InArg[scipy.sparse.csc_matrix]
-    number_of_vertices: InArg[int]
-    number_of_triangles: InArg[int]
-    edge_mean_length: InArg[float]
-    edge_min_length: InArg[float]
-    edge_max_length: InArg[float]
     hemisphere_mask: InArg[list]
-    zero_based_triangles: InArg[bool]
-    bi_hemispheric: InArg[bool]
-    valid_for_simulations: InArg[bool]
+    zero_based_triangles: InCompArg[bool]
 
     skinAir: OutArg[Surface]
 
@@ -131,20 +97,9 @@ class SkinAir(TVBComponent):
 @xai_component(color='rgb(0, 116, 92)')
 class BrainSkull(TVBComponent):
     file_path: InArg[str]
-    vertices: InArg[list]
-    triangles: InArg[list]
-    vertex_normals: InArg[list]
     triangle_normals: InArg[list]
-    geodesic_distance_matrix: InArg[scipy.sparse.csc_matrix]
-    number_of_vertices: InArg[int]
-    number_of_triangles: InArg[int]
-    edge_mean_length: InArg[float]
-    edge_min_length: InArg[float]
-    edge_max_length: InArg[float]
     hemisphere_mask: InArg[list]
-    zero_based_triangles: InArg[bool]
-    bi_hemispheric: InArg[bool]
-    valid_for_simulations: InArg[bool]
+    zero_based_triangles: InCompArg[bool]
 
     brainSkull: OutArg[Surface]
 
@@ -172,20 +127,9 @@ class BrainSkull(TVBComponent):
 @xai_component(color='rgb(0, 116, 92)')
 class SkullSkin(TVBComponent):
     file_path: InArg[str]
-    vertices: InArg[list]
-    triangles: InArg[list]
-    vertex_normals: InArg[list]
     triangle_normals: InArg[list]
-    geodesic_distance_matrix: InArg[scipy.sparse.csc_matrix]
-    number_of_vertices: InArg[int]
-    number_of_triangles: InArg[int]
-    edge_mean_length: InArg[float]
-    edge_min_length: InArg[float]
-    edge_max_length: InArg[float]
     hemisphere_mask: InArg[list]
-    zero_based_triangles: InArg[bool]
-    bi_hemispheric: InArg[bool]
-    valid_for_simulations: InArg[bool]
+    zero_based_triangles: InCompArg[bool]
 
     skullSkin: OutArg[Surface]
 
@@ -213,20 +157,9 @@ class SkullSkin(TVBComponent):
 @xai_component(color='rgb(0, 116, 92)')
 class EEGCap(TVBComponent):
     file_path: InArg[str]
-    vertices: InArg[list]
-    triangles: InArg[list]
-    vertex_normals: InArg[list]
     triangle_normals: InArg[list]
-    geodesic_distance_matrix: InArg[scipy.sparse.csc_matrix]
-    number_of_vertices: InArg[int]
-    number_of_triangles: InArg[int]
-    edge_mean_length: InArg[float]
-    edge_min_length: InArg[float]
-    edge_max_length: InArg[float]
     hemisphere_mask: InArg[list]
-    zero_based_triangles: InArg[bool]
-    bi_hemispheric: InArg[bool]
-    valid_for_simulations: InArg[bool]
+    zero_based_triangles: InCompArg[bool]
 
     eEGCap: OutArg[Surface]
 
@@ -254,20 +187,9 @@ class EEGCap(TVBComponent):
 @xai_component(color='rgb(0, 116, 92)')
 class FaceSurface(TVBComponent):
     file_path: InArg[str]
-    vertices: InArg[list]
-    triangles: InArg[list]
-    vertex_normals: InArg[list]
     triangle_normals: InArg[list]
-    geodesic_distance_matrix: InArg[scipy.sparse.csc_matrix]
-    number_of_vertices: InArg[int]
-    number_of_triangles: InArg[int]
-    edge_mean_length: InArg[float]
-    edge_min_length: InArg[float]
-    edge_max_length: InArg[float]
     hemisphere_mask: InArg[list]
-    zero_based_triangles: InArg[bool]
-    bi_hemispheric: InArg[bool]
-    valid_for_simulations: InArg[bool]
+    zero_based_triangles: InCompArg[bool]
 
     faceSurface: OutArg[Surface]
 


### PR DESCRIPTION
Some TVB classes have Attrs which are required and have no defaults provided. Thus, this PR contains code to transform the inputs of such TVB components into required inputs. Making the inputs required (in Xircuits they are called _compulsory_) prevents the user from running the workflow if those inputs have no values provided to them. The user is alerted via different visual cues (browser alert box/ component highlight) that there are missing values for required inputs.

This PR also contains some refactoring of different TVB components, usually for components initialized via `from_file()`. The `from_file()` method automatically sets the values on some inputs, so there is no need to reveal those inputs to the user.