### PR TITLE
WID-146. Compile file after pressing Run button in Remote run configuration

### DIFF
--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -878,8 +878,8 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		let pythonCode = getPythonCompiler(debuggerMode);
 		let showOutput = false;
 
-		// Only compile when 'Run' is chosen
-		if (runType == 'run') {
+		// Compile when Local or Remote run is selected
+		if (runType !== 'run-dont-compile') {
 			commands.execute(commandIDs.createArbitraryFile, { pythonCode, showOutput });
 			setCompiled(true);
 		}


### PR DESCRIPTION
This PR makes the Run button of the Xircuits canvas perform a compile step when the Remote run configuration is selected. 
This functionality was previously removed by Xircuits in their [PR #117](https://github.com/XpressAI/xircuits/pull/117). 