### PR TITLE
WID-162. Make unicore extension open with selected site

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "paths-js": "^0.4.11",
     "rc-dialog": "^8.6.0",
     "react-accessible-accordion": "^4.0.0",
-    "react-collapsed": "^3.6.0",
+    "react-collapsed": "^4.0.1",
     "react-draggable": "^4.4.4",
     "react-image-gallery": "^1.2.7",
     "react-numeric-input": "^2.2.3",

--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -24,6 +24,7 @@ import { cancelDialog, GeneralComponentLibrary } from '../tray_library/GeneralCo
 import { NodeActionsPanel } from '../context-menu/NodeActionsPanel';
 import { AdvancedComponentLibrary, fetchNodeByName } from '../tray_library/AdvanceComponentLib';
 import { inputDialog, getItsLiteralType } from '../dialog/LiteralInputDialog';
+import { readDefaultSite } from "../siteUtils";
 
 export interface BodyWidgetProps {
 	context: DocumentRegistry.Context;
@@ -1304,7 +1305,9 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		}
 		if (runType !== '' && runMonitoring) {
 			// It means a remote launch was started
-			await app.commands.execute(commandIDs.openTvbExtUnicore);
+			await app.commands.execute(commandIDs.openTvbExtUnicore, {
+          defaultSite: readDefaultSite()
+        });
 		}
 		return { commandStr, config };
 	};

--- a/src/dialog/RunDialog.tsx
+++ b/src/dialog/RunDialog.tsx
@@ -3,7 +3,8 @@ import TextareaAutosize from 'react-textarea-autosize';
 import React, { useEffect, useState } from 'react';
 import Switch from "react-switch";
 import { HTMLSelect } from "@jupyterlab/ui-components";
-import useCollapse from 'react-collapsed';
+import { useCollapse } from 'react-collapsed';
+import { writeDefaultSite } from "../siteUtils";
 
 export const RunDialog = ({
 	runTypes,
@@ -45,6 +46,7 @@ export const RunDialog = ({
 	 */
 	const handleConfigChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
 		let configName = event.target.value;
+		writeDefaultSite(configName);
 		setRunConfig(configName);
 		if (configName == "-") {
 			setCommand("");

--- a/src/siteUtils.ts
+++ b/src/siteUtils.ts
@@ -1,0 +1,9 @@
+const defaultSiteKey = 'tvb-ext-xircuits:defaultSite';
+
+export function writeDefaultSite(site: string): void {
+  localStorage.setItem(defaultSiteKey, site);
+}
+
+export function readDefaultSite(): string {
+  return localStorage.getItem(defaultSiteKey);
+}

--- a/src/xircuitFactory.ts
+++ b/src/xircuitFactory.ts
@@ -29,6 +29,7 @@ import { CommandIDs } from './log/LogPlugin';
 import { ServiceManager } from '@jupyterlab/services';
 import { RunSwitcher } from './components/RunSwitcher';
 import { lockIcon, xircuitsIcon } from './ui-components/icons';
+import { readDefaultSite } from './siteUtils';
 
 const XPIPE_CLASS = 'xircuits-editor';
 
@@ -267,7 +268,9 @@ export class XircuitFactory extends ABCWidgetFactory<DocumentWidget> {
       label: 'Monitor HPC',
       tooltip: 'Monitor your HPC jobs with tvb-ext-unicore',
       onClick: (): void => {
-        this.commands.execute(commandIDs.openTvbExtUnicore);
+        this.commands.execute(commandIDs.openTvbExtUnicore, {
+          defaultSite: readDefaultSite()
+        });
       }
     });
 


### PR DESCRIPTION
With this PR, when the user selects the "Remote Run" option and then selects a site, when launching `tvb-ext-unicore`, it will start and display the jobs for that specific site (in the past it always started with a default "None").

Also an upgrade of the `react-collapsed` module and its corresponding imports was made, as the "Remote Run" dialog stopped showing.