### PR TITLE
WID-92: store logs from xircuits run in files

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -300,15 +300,15 @@ const xircuits: JupyterFrontEndPlugin<void> = {
           await createPanel();
         }
 
-        // Convert the model_path to be bash aware
-        model_path = `"${model_path}"`
-
         outputPanel.session.ready.then(async () => {
           let code = startRunOutputStr();
           if (runType == 'remote-run') {
             // Run subprocess when run type is Remote Run
             code += doRemoteRun(model_path, config);
           } else {
+            // Convert the model_path to be bash aware
+            model_path = `"${model_path}"`
+
             code += `%run ${model_path} ${message} ${debug_mode}`
           }
 

--- a/xai_components/logger/builder.py
+++ b/xai_components/logger/builder.py
@@ -25,8 +25,16 @@ class LoggerBuilder(object):
         :param: config_file_name - name of the logging configuration relative to the current package
         """
         current_folder = os.path.dirname(inspect.getfile(self.__class__))
+
+        # TODO: name the log package after the xircuits file
+        log_package = os.path.join(os.getcwd(), 'log_files')
+
+        if not os.path.exists(log_package):
+            os.makedirs(log_package)
+
         config_file_path = os.path.join(current_folder, config_file_name)
-        logging.config.fileConfig(config_file_path, disable_existing_loggers=False)
+        logging.config.fileConfig(config_file_path, defaults={'package': log_package},
+                                  disable_existing_loggers=False)
         self._loggers = weakref.WeakValueDictionary()
 
     def build_logger(self, parent_module):

--- a/xai_components/logger/logging.conf
+++ b/xai_components/logger/logging.conf
@@ -38,7 +38,7 @@ args=(sys.stdout,)
 class=handlers.TimedRotatingFileHandler
 level=INFO
 formatter=simpleFormatter
-args=('.xai_components.log', 'midnight', 1, 30, None, False, False)
+args=(r'%(package)s/execution_time.log', 'H', 1, 30, None, False, False)
 
 ############################################
 ## Formatters                             ##


### PR DESCRIPTION
TODOs: 
- [ ]  name the package(where will store the logs) after the xircuits file
- [ ]  test on Remote run, for now I could not test it because of some JUSUF connection failure


