### PR TITLE
EBR-101. Fix description not showing for component and input ports

### DIFF
--- a/src/components/node/CustomNodeWidget.tsx
+++ b/src/components/node/CustomNodeWidget.tsx
@@ -380,7 +380,7 @@ const ComponentLibraryNode = ({ node, engine, shell, app, handleDeletableNode })
 
     const getDescriptionStr = () => {
         let dscrptStr = node['extras']['description'] ?? '***No description provided***';
-        setDescriptionStr(dscrptStr);
+        setDescriptionStr("")(dscrptStr);
     };
 
     const hideErrorTooltip = () => {
@@ -396,7 +396,6 @@ const ComponentLibraryNode = ({ node, engine, shell, app, handleDeletableNode })
                             onClick={async () => {
                                 setShowDescription(false);
                                 setShowParamDescriptionList(new Array(portsNo).fill(false));
-                                await handleDescription();
                             }}
                     >
                         <span aria-hidden="true">&times;</span>

--- a/style/ComponentInfo.css
+++ b/style/ComponentInfo.css
@@ -4,7 +4,7 @@
     border: 2px solid rgba(0, 253, 232, .5) !important;
     border-radius: 1px !important;
     opacity: 0.99 !important;
-    width: 450px;
+    width: 600px;
     position: absolute;
     top: calc(-250px - 2.5rem);
     left: -50%;

--- a/style/icons/info.svg
+++ b/style/icons/info.svg
@@ -1,7 +1,7 @@
 <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
     <polyline points="196 220 260 220 260 392" 
-        style="fill:none;stroke:#000;stroke-linecap:round;stroke-linejoin:round;stroke-width:40px"/>
+        style="fill:none;stroke:#fff;stroke-linecap:round;stroke-linejoin:round;stroke-width:40px"/>
     <line x1="187" y1="396" x2="325" y2="396" 
-        style="fill:none;stroke:#000;stroke-linecap:round;stroke-miterlimit:10;stroke-width:40px"/>
-    <path d="M256,160a32,32,0,1,1,32-32A32,32,0,0,1,256,160Z"/>
+        style="fill:none;stroke:#fff;stroke-linecap:round;stroke-miterlimit:10;stroke-width:40px"/>
+    <path d="M256,160a32,32,0,1,1,32-32A32,32,0,0,1,256,160Z" style="fill:#fff"/>
 </svg>


### PR DESCRIPTION
Fixed showing the description for components and input ports.
Decided not to show description on hover for tvb components; see this [Jira comment](https://tvb-projects.atlassian.net/browse/EBR-101?focusedCommentId=16244) for more details on this