### PR TITLE
VT-169. Add settings config files for different deployment environments

### DIFF
--- a/config/settings.hub.conf
+++ b/config/settings.hub.conf
@@ -1,0 +1,5 @@
+# Environment-specific configurations for the extension, depending on deployment context
+[defaults]
+base_directory_web = .
+base_directory_kernel = /
+enable_remote_libraries = false

--- a/config/settings.local.conf
+++ b/config/settings.local.conf
@@ -1,0 +1,5 @@
+# Environment-specific configurations for the extension, depending on deployment context
+[defaults]
+base_directory_web = .
+base_directory_kernel = .
+enable_remote_libraries = true

--- a/src/tray_library/Sidebar.tsx
+++ b/src/tray_library/Sidebar.tsx
@@ -371,12 +371,17 @@ export default function Sidebar(props: SidebarProps) {
                                 {mapCategories(category, componentList)}
                             </Accordion>
 
-                            <hr style={{ marginTop: "10px", marginBottom: "10px" }} />
-                            <h6 style={{ paddingLeft: "10px", margin: "0px", marginBottom: "8px" }}>AVAILABLE FOR
-                                INSTALLATION</h6>
-                            <Accordion>
-                                {mapRemoteLibraries()}
-                            </Accordion>
+                            {remoteLibList.length > 0 && (
+                                <>
+                                    <hr style={{ marginTop: "10px", marginBottom: "10px" }} />
+                                    <h6 style={{ paddingLeft: "10px", margin: "0px", marginBottom: "8px" }}>
+                                      AVAILABLE FOR INSTALLATION
+                                    </h6>
+                                    <Accordion>
+                                      {mapRemoteLibraries()}
+                                    </Accordion>
+                                </>
+                            )}
                         </>
                       ) : (
                         <div style={{margin: "10px"}}>

--- a/tvbextxircuits/library/generate_component_library_config.py
+++ b/tvbextxircuits/library/generate_component_library_config.py
@@ -3,6 +3,7 @@ import posixpath
 import json
 import toml
 from configparser import ConfigParser
+from tvbextxircuits.settings_loader import settings_config
 
 def parse_gitmodules(gitmodules_path):
     config = ConfigParser()
@@ -124,7 +125,17 @@ def get_component_library_config(filename=".xircuits/component_library_config.js
     if os.path.exists(filename):
         try:
             with open(filename, 'r') as json_file:
-                return json.load(json_file)
+                config = json.load(json_file)
+
+                # Check if remote libraries should be available for installation based on settings config
+                enable_remote = settings_config.get('enable_remote_libraries').lower() == 'true'
+
+                if not enable_remote:
+                    libraries = config.get('libraries', [])
+                    config['libraries'] = [lib for lib in libraries if lib.get('status') != 'remote']
+
+                return config
+
         except Exception as e:
             print(f"Error reading JSON file at {filename}: {e}")
             return None

--- a/tvbextxircuits/settings_loader.py
+++ b/tvbextxircuits/settings_loader.py
@@ -1,0 +1,36 @@
+import os
+import configparser
+
+from tvbextxircuits.logger.builder import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+def is_on_hub() -> bool:
+    """
+    Detect whether the extension is running in a JupyterHub environment (e.g., JSC).
+    We check for 'JUPYTERHUB_API_TOKEN', which is typically only set in JupyterHub.
+    Note: In the future we might want to do this smarter.
+    """
+    return bool(os.getenv('JUPYTERHUB_API_TOKEN'))
+
+
+def load_settings() -> dict[str, str]:
+    """
+    Load settings from the appropriate config file based on environment.
+    - JupyterHub: loads 'settings.hub.conf'
+    - Local: loads 'settings.local.conf'
+    """
+    config = configparser.ConfigParser()
+    filename = 'settings.hub.conf' if is_on_hub() else 'settings.local.conf'
+    config_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'config', filename))
+
+    if not os.path.exists(config_path):
+        LOGGER.error(f'Settings file not found: {config_path}')
+        return {}
+
+    config.read(config_path)
+    return dict(config['defaults'])
+
+
+settings_config = load_settings()

--- a/tvbextxircuits/utils.py
+++ b/tvbextxircuits/utils.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from jupyter_core.paths import jupyter_config_dir
 
 from tvbextxircuits.logger.builder import get_logger
+from tvbextxircuits.settings_loader import settings_config
 
 STORAGE_CONFIG_FILE = 'storage_config.json'  # To be used only for HPC runs
 COLLAB_NAME_KEY = 'collab_name'  # Used only for HPC runs
@@ -63,7 +64,8 @@ def get_user_settings():
 
 def get_base_dir_web():
     user_settings = get_user_settings()
-    base_dir = user_settings.get('baseDirectoryWeb', '.')  # if baseDirectory is not set, use a default value
+    default_base_dir_web = settings_config.get('base_directory_web')  # get default from settings config
+    base_dir = user_settings.get('baseDirectoryWeb', default_base_dir_web)
     LOGGER.info(f'Base directory Web in user settings is: {base_dir}')
     base_dir = os.path.abspath(os.path.expanduser(base_dir))
     return base_dir
@@ -71,7 +73,8 @@ def get_base_dir_web():
 
 def get_base_dir_kernel():
     user_settings = get_user_settings()
-    base_dir = user_settings.get('baseDirectoryKernel', '.')  # if baseDirectory is not set, use a default value
+    default_base_dir_kernel = settings_config.get('base_directory_kernel')  # get default from settings config
+    base_dir = user_settings.get('baseDirectoryKernel', default_base_dir_kernel)
     LOGGER.info(f'Base directory Kernel in user settings is: {base_dir}')
     base_dir = os.path.abspath(os.path.expanduser(base_dir))
     return base_dir


### PR DESCRIPTION
In this PR we handle different deployment environments (e.g. local vs JSC), which is necessary since he have different default behaviors for the 2 alternatives.