### PR TITLE
docs: add docstrings to TVB simulation components

### DIFF
--- a/xai_components/xai_connectivity/connectivity.py
+++ b/xai_components/xai_connectivity/connectivity.py
@@ -13,6 +13,22 @@ from xai_components.utils import print_component_summary
 
 @xai_component(color='rgb(85, 37, 130)')
 class ConnectivityFromFile(TVBComponent):
+    """Xircuits component for loading brain connectivity from a file.
+
+    Loads a TVB Connectivity object from a zip file containing structural
+    connection data (weights, tract lengths, region centres, and labels).
+    If no file path is provided, the default 76-region parcellation from
+    tvb_data is used. After loading, a visualization of the connectivity
+    weight matrix is displayed.
+
+    Inputs:
+        file_path: Path to a connectivity zip file. If not provided,
+                   defaults to 'connectivity_76.zip' from tvb_data.
+
+    Output:
+        connectivity: Configured TVB Connectivity object containing
+                      weights, tract lengths, and region information.
+    """
     file_path: InArg[str]
 
     connectivity: OutArg[Connectivity]

--- a/xai_components/xai_tvb_models/linear.py
+++ b/xai_components/xai_tvb_models/linear.py
@@ -15,6 +15,21 @@ from xai_components.utils import print_component_summary, set_values
 
 @xai_component(color='rgb(101, 179, 46)')
 class LinearModel(ComponentWithWidget):
+    """Xircuits component for the Linear neural mass model.
+
+    A simple linear model where the dynamics follow a first-order linear
+    differential equation. Useful for testing simulation pipelines and
+    as a baseline model for comparison with more complex neural models.
+
+    Inputs:
+        gamma: Rate constant controlling the decay of the linear model.
+               Determines how quickly the state variable returns to equilibrium.
+        variables_of_interest: List of state variables to record during simulation.
+        parameter_names: List of parameter names used by the model.
+
+    Output:
+        linear: Configured TVB Linear model instance.
+    """
     gamma: InArg[Union[float, numpy.ndarray]]
     variables_of_interest: InArg[list]
     parameter_names: InArg[list]

--- a/xai_components/xai_tvb_models/oscillator.py
+++ b/xai_components/xai_tvb_models/oscillator.py
@@ -15,6 +15,30 @@ from xai_components.utils import print_component_summary, set_values
 
 @xai_component(color='rgb(101, 179, 46)')
 class Generic2dOscillator(ComponentWithWidget):
+    """Xircuits component for the Generic 2D Oscillator neural mass model.
+
+    A two-dimensional oscillator model that can reproduce the dynamics of
+    several well-known neural models depending on the parameter configuration.
+    It is commonly used for simulating basic neural population dynamics in TVB.
+
+    Inputs:
+        tau: Time scale of the model dynamics.
+        I: External input current driving the system.
+        a: Model parameter controlling the shape of the nullcline.
+        b: Model parameter affecting the fast variable dynamics.
+        c: Model parameter for the slow variable influence.
+        d: Time scale ratio between fast and slow variables.
+        e: Coefficient for the quadratic term.
+        f: Coefficient for the cubic term.
+        g: Coefficient for the linear coupling term.
+        alpha: Scaling parameter for the fast variable.
+        beta: Scaling parameter for the slow variable.
+        gamma: Additional scaling parameter.
+        variables_of_interest: List of state variables to record during simulation.
+
+    Output:
+        generic2dOscillator: Configured TVB Generic2dOscillator model instance.
+    """
     tau: InArg[Union[float, numpy.ndarray]]
     I: InArg[Union[float, numpy.ndarray]]
     a: InArg[Union[float, numpy.ndarray]]
@@ -46,6 +70,19 @@ class Generic2dOscillator(ComponentWithWidget):
 
 @xai_component(color='rgb(101, 179, 46)')
 class Kuramoto(ComponentWithWidget):
+    """Xircuits component for the Kuramoto coupled oscillator model.
+
+    The Kuramoto model describes the synchronization behavior of coupled
+    oscillators. Each oscillator has a natural frequency and tends to
+    synchronize with its neighbors through coupling.
+
+    Inputs:
+        omega: Natural frequency of the oscillators.
+        variables_of_interest: List of state variables to record during simulation.
+
+    Output:
+        kuramoto: Configured TVB Kuramoto model instance.
+    """
     omega: InArg[Union[float, numpy.ndarray]]
     variables_of_interest: InArg[list]
 
@@ -66,6 +103,22 @@ class Kuramoto(ComponentWithWidget):
 
 @xai_component(color='rgb(101, 179, 46)')
 class SupHopf(ComponentWithWidget):
+    """Xircuits component for the Supercritical Hopf bifurcation model.
+
+    The Supercritical Hopf model describes the transition from a stable
+    fixed point to a limit cycle oscillation. It is used to model the
+    onset of neural oscillations in brain regions.
+
+    Inputs:
+        a: Bifurcation parameter controlling the transition between
+           stable and oscillatory states. Negative values produce a
+           stable fixed point, positive values produce oscillations.
+        omega: Natural frequency of the oscillations.
+        variables_of_interest: List of state variables to record during simulation.
+
+    Output:
+        supHopf: Configured TVB SupHopf model instance.
+    """
     a: InArg[Union[float, numpy.ndarray]]
     omega: InArg[Union[float, numpy.ndarray]]
     variables_of_interest: InArg[list]

--- a/xai_components/xai_tvb_noise/noise.py
+++ b/xai_components/xai_tvb_noise/noise.py
@@ -15,6 +15,27 @@ from xai_components.utils import print_component_summary, set_defaults, set_valu
 
 @xai_component(color='rgb(253, 225, 0)')
 class Additive(TVBComponent):
+    """Xircuits component for configuring additive noise in TVB simulations.
+
+    Additive noise introduces random fluctuations to the simulation state
+    variables that are independent of the current system state. This is
+    the most common noise type used in stochastic brain simulations.
+
+    Inputs:
+        ntau: Noise correlation time constant. Controls the temporal
+              smoothness of the noise signal.
+        noise_seed: Seed for the random number generator, enabling
+                    reproducible noise across simulation runs.
+        random_stream: NumPy RandomState object for generating the
+                       random noise values.
+        nsig: Noise amplitude (standard deviation). Can be a single
+              float for uniform noise or a numpy array for different
+              noise levels per state variable.
+
+    Output:
+        additive: Configured TVB Additive noise instance ready to be
+                  connected to an integrator component.
+    """
     ntau: InArg[float]
     noise_seed: InArg[int]
     random_stream: InArg[numpy.random.RandomState]
@@ -40,6 +61,29 @@ class Additive(TVBComponent):
 
 @xai_component(color='rgb(253, 225, 0)')
 class Multiplicative(TVBComponent):
+    """Xircuits component for configuring multiplicative noise in TVB simulations.
+
+    Multiplicative noise produces state-dependent random fluctuations where
+    the noise amplitude is modulated by a temporal equation applied to the
+    current system state. This creates more realistic noise patterns where
+    the variability scales with neural activity.
+
+    Inputs:
+        ntau: Noise correlation time constant. Controls the temporal
+              smoothness of the noise signal.
+        noise_seed: Seed for the random number generator, enabling
+                    reproducible noise across simulation runs.
+        random_stream: NumPy RandomState object for generating the
+                       random noise values.
+        nsig: Noise amplitude (standard deviation). Can be a single
+              float or a numpy array for per-variable noise levels.
+        b: Temporal equation that governs how the noise amplitude
+           depends on the current state of the system.
+
+    Output:
+        multiplicative: Configured TVB Multiplicative noise instance
+                        ready to be connected to an integrator component.
+    """
     from tvb.datatypes.equations import TemporalApplicableEquation
     ntau: InArg[float]
     noise_seed: InArg[int]
@@ -63,4 +107,3 @@ class Multiplicative(TVBComponent):
         set_values(self, multiplicative)
         self.multiplicative.value = multiplicative
         print_component_summary(self.multiplicative.value)
-

--- a/xai_components/xai_tvb_simulator/simulator.py
+++ b/xai_components/xai_tvb_simulator/simulator.py
@@ -18,6 +18,36 @@ from xai_components.utils import print_component_summary, set_defaults, set_valu
 
 @xai_component(color='rgb(220, 5, 45)')
 class Simulator(TVBComponent):
+    """Xircuits component for running TVB brain network simulations.
+
+    This is the central simulation component that brings together all the
+    pieces needed for a full brain simulation: connectivity, neural mass
+    model, coupling function, integrator, and monitors. It configures
+    a TVB Simulator, runs the simulation, and produces time series output
+    for each monitor.
+
+    Inputs:
+        connectivity: Brain connectivity matrix defining the structural
+                      connections between brain regions (weights and tract lengths).
+        conduction_speed: Speed of signal propagation between regions in mm/ms.
+        coupling: Coupling function defining how connected regions influence
+                  each other during simulation.
+        surface: Optional cortical surface mesh for surface-based simulations.
+        stimulus: Optional spatiotemporal stimulation pattern applied during
+                  the simulation.
+        model: Neural mass model describing the local dynamics at each
+               brain region (e.g., Generic2dOscillator, Epileptor).
+        integrator: Numerical integration scheme used to solve the model
+                    equations (e.g., HeunDeterministic, EulerStochastic).
+        initial_conditions: Optional initial state values for the simulation.
+        monitors: List of monitors that define what data to record and at
+                  what sampling rate (e.g., TemporalAverage, Raw).
+        simulation_length: Total duration of the simulation in milliseconds.
+
+    Output:
+        time_series_list: List of TimeSeries objects, one for each monitor,
+                          containing the recorded simulation data.
+    """
     connectivity: InCompArg[Connectivity]
     conduction_speed: InArg[float]
     coupling: InArg[Coupling]


### PR DESCRIPTION
# Description

While going through the codebase to understand how the TVB 
components are built, I noticed that most of the component 
classes don't have any docstrings. Since there are quite a 
few components and they each have different parameters, I 
thought it would be helpful to add some documentation so 
that new contributors (and users browsing the code) can 
quickly understand what each component does without having 
to dig into the TVB library source.

This PR adds docstrings to these components:

- **oscillator.py** — Generic2dOscillator, Kuramoto, SupHopf
- **linear.py** — LinearModel
- **simulator.py** — Simulator
- **connectivity.py** — ConnectivityFromFile
- **noise.py** — Additive, Multiplicative

Each docstring briefly explains what the component is for, 
what the input parameters mean, and what the output gives you.

Nothing functional has been changed — just documentation.

## References

N/A

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [x] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Tests

Since this is a documentation-only change, no tests were 
needed. The docstrings don't affect any runtime behavior.

# Notes

If this looks good to the team, I'm happy to add docstrings 
to the remaining model files too (epileptor, wilson_cowan, 
wong_wang, etc.). Just let me know!