### PR TITLE
docs: add troubleshooting section for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,27 @@ To be able to see details info related to TVB components you must first run the 
 
 Notebooks generated can be found at `TVB_generated_notebooks/<xircuits_id>`
 
+## Troubleshooting for dev mode setup
+**Issue:** The terminal returns `zsh: command not found: tvbextxircuits` despite a successful installation.
+
+**Root Cause:** When installing with `uv` or other virtual environment tools, the executable binaries are located within the virtual environment's `bin` directory. If the environment is not activated, or if the local `bin` path is not added to your system's global `PATH` variable, the shell cannot locate the command.
+
+**Solutions:**
+
+* **Option A: Manual Activation (Recommended)**
+Always ensure your virtual environment is active before running the tool. This ensures all dependencies and scripts are correctly mapped.
+```zsh
+cd tvb-ext-xircuits
+source .venv/bin/activate
+tvbextxircuits
+```
+
+* **Option B: Direct Path Execution**
+If you want to launch the service quickly without full activation, call the binary directly using its relative path:
+```zsh
+./.venv/bin/tvbextxircuits
+```
+
 ##  Acknowledgments
 
 Copyright (c) 2022-2025 to Xircuits Team See: https://github.com/XpressAI/xircuits


### PR DESCRIPTION
# Description

This PR adds a **Troubleshooting** section to the `README.md` to help users resolve the `zsh: command not found: tvbextxircuits` error.

## References

None. This PR is based on personal dev-environment setup experience where uv managers are used.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [x] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Tests

**Verification of Troubleshooting Commands**

1. Installed the extension in a fresh virtual environment using `uv`.
    
2. Verified that `tvbextxircuits` returned `command not found` before activation.
    
3. Executed **Option A** (manual activation) and confirmed the command worked.
    
4. Executed **Option B** (direct path) and confirmed the binary launched correctly.

**Tested on? Specify Version.**

- [ ] Windows  
- [ ] Linux
- [x] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

While the main README focuses on `conda`, many contributors using `uv`  encounter this path issue. I'll be happy if this addition helps contributors using different environment managers.
