### PR TITLE
Add documentation for example circuits

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,33 @@
+# Example Circuits
+
+This directory contains example Xircuits circuits demonstrating different
+features of the `tvb-ext-xircuits` extension.
+
+## Available Examples
+
+### HelloXircuits.xircuits
+A simple introductory circuit used to verify that the Xircuits environment
+is working correctly.
+
+### ControlflowExample.xircuits
+Demonstrates control flow structures such as conditional execution.
+
+### DynamicPorts.xircuits
+Shows how dynamic ports can be used when constructing circuits.
+
+### ParallelSimulations.xircuits
+Example demonstrating parallel simulation execution.
+
+### SettingVariables.xircuits
+Illustrates how to define and modify variables within circuits.
+
+## Running the examples
+
+1. Launch **JupyterLab**.
+2. Open the **Xircuits interface**.
+3. Navigate to the `examples` directory.
+4. Load one of the `.xircuits` files.
+5. Execute the nodes in sequence.
+
+These examples are useful for understanding how to build workflows using
+Xircuits and the TVB extensions.


### PR DESCRIPTION
## Description

This PR adds documentation for the example circuits located in the `examples` directory.

A new `README.md` file has been added which explains the purpose of the example circuits and provides basic instructions on how users can run them using the Xircuits interface in JupyterLab.

This improves the discoverability and usability of the example workflows for new contributors and users exploring the repository.

## Pull Request Type

- [x] Documentation

## Type of Change

- [x] This change requires a documentation update

## Tests

No functional code changes were introduced.  
This change only adds documentation for existing example circuits.