### PR TITLE
feat: add PSE components for parameter space exploration workflows

### DIFF
--- a/examples/ParameterSpaceExploration_2D.xircuits
+++ b/examples/ParameterSpaceExploration_2D.xircuits
@@ -1,0 +1,76 @@
+{
+  "graph": {
+    "cells": [
+      {
+        "type": "Start",
+        "position": { "x": 50, "y": 200 },
+        "size": { "width": 60, "height": 60 },
+        "id": "start-node"
+      },
+      {
+        "type": "xircuits.PSELinspaceRange",
+        "position": { "x": 200, "y": 100 },
+        "size": { "width": 200, "height": 100 },
+        "id": "pse-linspace-1",
+        "attrs": {
+          "params": {
+            "start": 0.0,
+            "stop": 2.0,
+            "num_points": 5
+          }
+        }
+      },
+      {
+        "type": "xircuits.PSEArangeRange",
+        "position": { "x": 200, "y": 250 },
+        "size": { "width": 200, "height": 100 },
+        "id": "pse-arange-1",
+        "attrs": {
+          "params": {
+            "start": 2.0,
+            "stop": 6.0,
+            "step": 1.0
+          }
+        }
+      },
+      {
+        "type": "xircuits.PSEParameterGrid",
+        "position": { "x": 500, "y": 175 },
+        "size": { "width": 200, "height": 100 },
+        "id": "pse-grid"
+      },
+      {
+        "type": "End",
+        "position": { "x": 800, "y": 200 },
+        "size": { "width": 60, "height": 60 },
+        "id": "end-node"
+      }
+    ],
+    "links": [
+      {
+        "type": "xircuits.Wire",
+        "source": { "id": "start-node" },
+        "target": { "id": "pse-linspace-1" },
+        "id": "link-1"
+      },
+      {
+        "type": "xircuits.Wire",
+        "source": { "id": "pse-linspace-1" },
+        "target": { "id": "pse-grid" },
+        "id": "link-2"
+      },
+      {
+        "type": "xircuits.Wire",
+        "source": { "id": "pse-arange-1" },
+        "target": { "id": "pse-grid" },
+        "id": "link-3"
+      },
+      {
+        "type": "xircuits.Wire",
+        "source": { "id": "pse-grid" },
+        "target": { "id": "end-node" },
+        "id": "link-4"
+      }
+    ]
+  }
+}

--- a/examples/README_PSE.md
+++ b/examples/README_PSE.md
@@ -1,0 +1,30 @@
+# Parameter Space Exploration (PSE) Examples
+
+## Overview
+
+The PSE components enable automated parameter sweeps over TVB model parameters.
+
+## Quick Start
+
+    cd examples
+    python parameter_space_exploration_demo.py
+
+## Components
+
+### Range Components
+- PSELinspaceRange - Linear spacing
+- PSEArangeRange - Arithmetic progression
+- PSEValueList - Custom values
+
+### Grid Component
+- PSEParameterGrid - 2D Cartesian product
+
+### Metric Components
+- PSEResultCollector - Accumulates results
+- PSEGlobalVariance - Computes variance
+- PSEVarianceOfVariance - Variance of variance
+
+## Files
+- README_PSE.md - This file
+- parameter_space_exploration_demo.py - Working demo
+- outputs/ - Generated visualizations

--- a/examples/parameter_space_exploration_demo.py
+++ b/examples/parameter_space_exploration_demo.py
@@ -1,0 +1,121 @@
+"""
+Parameter Space Exploration Demo
+=================================
+Demonstrates the PSE components for automated parameter sweeps.
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
+import numpy as np
+from xai_components.xai_pse.range_components import PSELinspaceRange, PSEArangeRange
+from xai_components.xai_pse.grid_components import PSEParameterGrid
+from xai_components.xai_pse.metric_components import PSEResultCollector, PSEGlobalVariance
+
+def main():
+    print("=" * 70)
+    print("TVB Parameter Space Exploration Demo")
+    print("=" * 70)
+
+    print("\n[Step 1] Defining parameter ranges...")
+    
+    # Create G range component
+    G_range = PSELinspaceRange()
+    G_range.start.value = 0.0
+    G_range.stop.value = 2.0
+    G_range.num_points.value = 5
+    G_range.execute(None)
+
+    # Create speed range component
+    speed_range = PSEArangeRange()
+    speed_range.start.value = 2.0
+    speed_range.stop.value = 6.0
+    speed_range.step.value = 1.0
+    speed_range.execute(None)
+
+    print("\n[Step 2] Creating parameter grid...")
+    grid = PSEParameterGrid()
+    grid.param1_values.value = G_range.values.value
+    grid.param2_values.value = speed_range.values.value
+    grid.param1_name.value = "G"
+    grid.param2_name.value = "speed"
+    grid.execute({})  # Pass empty dict as context
+    
+    combinations = grid.grid_combinations.value
+    print(f"  First 3 combinations:")
+    for i, combo in enumerate(combinations[:3], 1):
+        print(f"    {i}. G={combo[0]:.2f}, speed={combo[1]:.2f}")
+
+    print(f"\n[Step 3] Running {len(combinations)} simulations...")
+    
+    # Collect all results
+    all_results = []
+    for i, (g_val, speed_val) in enumerate(combinations, 1):
+        # Generate mock time series
+        time_points = 1000
+        time_series = np.random.randn(time_points, 1, 76, 1)
+        signal_strength = g_val * speed_val / 5.0
+        time_series += signal_strength * np.sin(np.linspace(0, 10*np.pi, time_points))[:, None, None, None]
+        
+        all_results.append(time_series)
+        
+        if i % 5 == 0:
+            print(f"  [OK] Completed {i}/{len(combinations)}")
+    
+    print("  [OK] All simulations complete!")
+
+    print("\n[Step 4] Computing global variance...")
+    variance_metric = PSEGlobalVariance()
+    variance_metric.simulation_results.value = all_results
+    variance_metric.grid_shape.value = grid.grid_shape.value
+    variance_metric.execute(None)
+    
+    variance_matrix = variance_metric.metric_matrix.value
+    print(f"  [OK] Variance matrix shape: {variance_matrix.shape}")
+    print(f"  [OK] Min: {np.nanmin(variance_matrix):.4f}")
+    print(f"  [OK] Max: {np.nanmax(variance_matrix):.4f}")
+    print(f"  [OK] Mean: {np.nanmean(variance_matrix):.4f}")
+
+    print("\n[Step 5] Creating visualization...")
+    try:
+        import matplotlib.pyplot as plt
+        import seaborn as sns
+        
+        os.makedirs('outputs', exist_ok=True)
+        
+        plt.figure(figsize=(10, 8))
+        sns.heatmap(
+            variance_matrix,
+            xticklabels=[f'{x:.1f}' for x in grid.param2_axis.value],
+            yticklabels=[f'{y:.1f}' for y in grid.param1_axis.value],
+            cmap='viridis',
+            annot=True,
+            fmt='.3f',
+            cbar_kws={'label': 'Global Variance'}
+        )
+        plt.xlabel('Conduction Speed', fontsize=12)
+        plt.ylabel('Global Coupling (G)', fontsize=12)
+        plt.title('Parameter Space Exploration - Global Variance', fontsize=14, fontweight='bold')
+        plt.tight_layout()
+        plt.savefig('outputs/pse_demo_heatmap.png', dpi=300, bbox_inches='tight')
+        print("  [OK] Heatmap saved to outputs/pse_demo_heatmap.png")
+    except ImportError:
+        print("  [!] Visualization skipped (install: pip install matplotlib seaborn)")
+    except Exception as e:
+        print(f"  [!] Visualization error: {e}")
+
+    print("\n" + "=" * 70)
+    print("[DONE] Parameter Space Exploration Demo Complete!")
+    print("=" * 70)
+    print(f"\nSummary:")
+    print(f"  - Parameters explored: 2 (G, speed)")
+    print(f"  - Grid shape: {grid.grid_shape.value}")
+    print(f"  - Total simulations: {grid.total_simulations.value}")
+    print(f"  - Variance range: {np.nanmin(variance_matrix):.4f} - {np.nanmax(variance_matrix):.4f}")
+    if os.path.exists('outputs/pse_demo_heatmap.png'):
+        print(f"  - Visualization: outputs/pse_demo_heatmap.png")
+    print("=" * 70)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pse_components.py
+++ b/tests/test_pse_components.py
@@ -1,0 +1,311 @@
+﻿# -*- coding: utf-8 -*-
+#
+# Unit tests for PSE components
+#
+import pytest
+import numpy
+
+from xai_components.base import InArg, OutArg
+
+
+def _set(comp, attr, val):
+    setattr(comp, attr, InArg(val))
+
+
+def _out(comp, attr):
+    setattr(comp, attr, OutArg(None))
+
+
+class TestPSELinspaceRange:
+
+    def _make(self, start=0.0, stop=1.0, num_points=5):
+        from xai_components.xai_pse.range_components import PSELinspaceRange
+        comp = PSELinspaceRange()
+        _set(comp, 'start', start)
+        _set(comp, 'stop', stop)
+        _set(comp, 'num_points', num_points)
+        _out(comp, 'values')
+        return comp
+
+    def test_basic_range(self):
+        comp = self._make(0.0, 1.0, 5)
+        comp.execute({})
+        result = comp.values.value
+        assert len(result) == 5
+        numpy.testing.assert_allclose(result, [0.0, 0.25, 0.5, 0.75, 1.0])
+
+    def test_two_points(self):
+        comp = self._make(0.0, 10.0, 2)
+        comp.execute({})
+        assert comp.values.value == [0.0, 10.0]
+
+    def test_output_is_list(self):
+        comp = self._make(0.0, 1.0, 3)
+        comp.execute({})
+        assert isinstance(comp.values.value, list)
+
+    def test_large_range(self):
+        comp = self._make(0.0, 100.0, 101)
+        comp.execute({})
+        assert len(comp.values.value) == 101
+
+    def test_invalid_num_points_zero(self):
+        comp = self._make(0.0, 1.0, 0)
+        with pytest.raises(ValueError, match="num_points must be >= 1"):
+            comp.execute({})
+
+    def test_start_ge_stop(self):
+        comp = self._make(5.0, 2.0, 10)
+        with pytest.raises(ValueError, match="start.*must be < stop"):
+            comp.execute({})
+
+    def test_defaults_when_none(self):
+        from xai_components.xai_pse.range_components import PSELinspaceRange
+        comp = PSELinspaceRange()
+        _set(comp, 'start', None)
+        _set(comp, 'stop', None)
+        _set(comp, 'num_points', None)
+        _out(comp, 'values')
+        comp.execute({})
+        assert len(comp.values.value) == 10
+        assert comp.values.value[0] == 0.0
+        assert comp.values.value[-1] == 1.0
+
+
+class TestPSEArangeRange:
+
+    def _make(self, start=0.0, stop=1.0, step=0.25):
+        from xai_components.xai_pse.range_components import PSEArangeRange
+        comp = PSEArangeRange()
+        _set(comp, 'start', start)
+        _set(comp, 'stop', stop)
+        _set(comp, 'step', step)
+        _out(comp, 'values')
+        return comp
+
+    def test_basic_arange(self):
+        comp = self._make(0.0, 1.0, 0.25)
+        comp.execute({})
+        result = comp.values.value
+        assert len(result) == 4
+        numpy.testing.assert_allclose(result, [0.0, 0.25, 0.5, 0.75])
+
+    def test_output_is_list(self):
+        comp = self._make(0.0, 0.5, 0.1)
+        comp.execute({})
+        assert isinstance(comp.values.value, list)
+
+    def test_negative_step_raises(self):
+        comp = self._make(0.0, 1.0, -0.1)
+        with pytest.raises(ValueError, match="step must be > 0"):
+            comp.execute({})
+
+    def test_start_ge_stop_raises(self):
+        comp = self._make(5.0, 2.0, 0.1)
+        with pytest.raises(ValueError, match="start.*must be < stop"):
+            comp.execute({})
+
+
+class TestPSEValueList:
+
+    def _make(self, csv_string):
+        from xai_components.xai_pse.range_components import PSEValueList
+        comp = PSEValueList()
+        _set(comp, 'values_string', csv_string)
+        _out(comp, 'values')
+        return comp
+
+    def test_parse_csv(self):
+        comp = self._make("0.1, 0.5, 1.0, 2.5")
+        comp.execute({})
+        assert comp.values.value == [0.1, 0.5, 1.0, 2.5]
+
+    def test_single_value(self):
+        comp = self._make("42.0")
+        comp.execute({})
+        assert comp.values.value == [42.0]
+
+    def test_whitespace(self):
+        comp = self._make("  1.0 ,  2.0 ,  3.0  ")
+        comp.execute({})
+        assert comp.values.value == [1.0, 2.0, 3.0]
+
+    def test_empty_raises(self):
+        comp = self._make("")
+        with pytest.raises(ValueError, match="cannot be empty"):
+            comp.execute({})
+
+    def test_none_raises(self):
+        comp = self._make(None)
+        with pytest.raises(ValueError, match="cannot be empty"):
+            comp.execute({})
+
+    def test_non_numeric_raises(self):
+        comp = self._make("a, b, c")
+        with pytest.raises(ValueError, match="could not parse"):
+            comp.execute({})
+
+
+class TestPSEParameterGrid:
+
+    def _make(self, p1, p2, name1="coupling", name2="speed"):
+        from xai_components.xai_pse.grid_components import PSEParameterGrid
+        comp = PSEParameterGrid()
+        _set(comp, 'param1_values', p1)
+        _set(comp, 'param2_values', p2)
+        _set(comp, 'param1_name', name1)
+        _set(comp, 'param2_name', name2)
+        _out(comp, 'grid_combinations')
+        _out(comp, 'param1_axis')
+        _out(comp, 'param2_axis')
+        _out(comp, 'grid_shape')
+        _out(comp, 'total_simulations')
+        return comp
+
+    def test_basic_grid(self):
+        comp = self._make([1.0, 2.0, 3.0], [10.0, 20.0])
+        comp.execute({})
+        combos = comp.grid_combinations.value
+        assert len(combos) == 6
+        assert (1.0, 10.0) in combos
+        assert (3.0, 20.0) in combos
+
+    def test_grid_shape(self):
+        comp = self._make([1.0, 2.0], [5.0, 6.0, 7.0])
+        comp.execute({})
+        assert comp.grid_shape.value == (2, 3)
+        assert comp.total_simulations.value == 6
+
+    def test_single_values(self):
+        comp = self._make([1.0], [2.0])
+        comp.execute({})
+        assert comp.grid_combinations.value == [(1.0, 2.0)]
+        assert comp.total_simulations.value == 1
+
+    def test_context_metadata(self):
+        ctx = {}
+        comp = self._make([1.0, 2.0], [5.0], "G", "tau")
+        comp.execute(ctx)
+        assert ctx["pse_param1_name"] == "G"
+        assert ctx["pse_param2_name"] == "tau"
+        assert ctx["pse_grid_shape"] == (2, 1)
+
+    def test_empty_param1_raises(self):
+        comp = self._make([], [1.0])
+        with pytest.raises(ValueError, match="param1_values is empty"):
+            comp.execute({})
+
+    def test_none_param2_raises(self):
+        comp = self._make([1.0], None)
+        with pytest.raises(ValueError, match="param2_values is empty"):
+            comp.execute({})
+
+
+class TestPSEResultCollector:
+
+    def _make(self, single, accumulated):
+        from xai_components.xai_pse.metric_components import PSEResultCollector
+        comp = PSEResultCollector()
+        _set(comp, 'single_result', single)
+        _set(comp, 'accumulated', accumulated)
+        _out(comp, 'accumulated_out')
+        _out(comp, 'count')
+        return comp
+
+    def test_first_collection(self):
+        comp = self._make(numpy.array([1, 2, 3]), None)
+        comp.execute({})
+        assert comp.count.value == 1
+        assert len(comp.accumulated_out.value) == 1
+
+    def test_accumulation(self):
+        existing = [numpy.array([1, 2]), numpy.array([3, 4])]
+        comp = self._make(numpy.array([5, 6]), existing)
+        comp.execute({})
+        assert comp.count.value == 3
+
+    def test_none_result_raises(self):
+        comp = self._make(None, [])
+        with pytest.raises(ValueError, match="single_result is None"):
+            comp.execute({})
+
+
+class TestPSEGlobalVariance:
+
+    def _make(self, results, shape):
+        from xai_components.xai_pse.metric_components import PSEGlobalVariance
+        comp = PSEGlobalVariance()
+        _set(comp, 'simulation_results', results)
+        _set(comp, 'grid_shape', shape)
+        _out(comp, 'metric_values')
+        _out(comp, 'metric_matrix')
+        _out(comp, 'metric_name')
+        return comp
+
+    def test_zero_variance(self):
+        results = [numpy.zeros(100), numpy.ones(100)]
+        comp = self._make(results, (1, 2))
+        comp.execute({})
+        assert comp.metric_values.value[0] == 0.0
+        assert comp.metric_values.value[1] == 0.0
+
+    def test_nonzero_variance(self):
+        results = [numpy.arange(100, dtype=float)]
+        comp = self._make(results, (1, 1))
+        comp.execute({})
+        assert comp.metric_values.value[0] > 0
+
+    def test_matrix_shape(self):
+        results = [numpy.random.randn(50) for _ in range(6)]
+        comp = self._make(results, (2, 3))
+        comp.execute({})
+        assert comp.metric_matrix.value.shape == (2, 3)
+
+    def test_metric_name(self):
+        results = [numpy.array([1.0])]
+        comp = self._make(results, (1, 1))
+        comp.execute({})
+        assert comp.metric_name.value == "Global Variance"
+
+    def test_empty_raises(self):
+        comp = self._make([], (0, 0))
+        with pytest.raises(ValueError, match="no simulation results"):
+            comp.execute({})
+
+
+class TestPSEVarianceOfVariance:
+
+    def _make(self, results, shape):
+        from xai_components.xai_pse.metric_components import PSEVarianceOfVariance
+        comp = PSEVarianceOfVariance()
+        _set(comp, 'simulation_results', results)
+        _set(comp, 'grid_shape', shape)
+        _out(comp, 'metric_values')
+        _out(comp, 'metric_matrix')
+        _out(comp, 'metric_name')
+        return comp
+
+    def test_uniform_low_vov(self):
+        uniform = numpy.ones((100, 1, 10, 1))
+        comp = self._make([uniform], (1, 1))
+        comp.execute({})
+        assert comp.metric_values.value[0] == 0.0
+
+    def test_heterogeneous_high_vov(self):
+        ts = numpy.zeros((100, 1, 5, 1))
+        for region in range(5):
+            ts[:, 0, region, 0] = numpy.random.randn(100) * (region + 1)
+        comp = self._make([ts], (1, 1))
+        comp.execute({})
+        assert comp.metric_values.value[0] > 0
+
+    def test_metric_name(self):
+        results = [numpy.random.randn(50, 1, 10, 1)]
+        comp = self._make(results, (1, 1))
+        comp.execute({})
+        assert comp.metric_name.value == "Variance of Variance"
+
+    def test_empty_raises(self):
+        comp = self._make([], None)
+        with pytest.raises(ValueError, match="no simulation results"):
+            comp.execute({})

--- a/xai_components/xai_pse/__init__.py
+++ b/xai_components/xai_pse/__init__.py
@@ -1,0 +1,3 @@
+﻿from xai_components.xai_pse.range_components import PSELinspaceRange, PSEArangeRange, PSEValueList
+from xai_components.xai_pse.grid_components import PSEParameterGrid
+from xai_components.xai_pse.metric_components import PSEResultCollector, PSEGlobalVariance, PSEVarianceOfVariance

--- a/xai_components/xai_pse/grid_components.py
+++ b/xai_components/xai_pse/grid_components.py
@@ -1,0 +1,73 @@
+﻿# -*- coding: utf-8 -*-
+#
+# "TheVirtualBrain - Widgets" package
+#
+# (c) 2022-2025, TVB Widgets Team
+#
+
+import itertools
+from xai_components.base import Component, InArg, OutArg, xai_component
+
+
+@xai_component(color='rgb(92, 107, 192)')
+class PSEParameterGrid(Component):
+    param1_values: InArg[list]
+    param2_values: InArg[list]
+    param1_name: InArg[str]
+    param2_name: InArg[str]
+    grid_combinations: OutArg[list]
+    param1_axis: OutArg[list]
+    param2_axis: OutArg[list]
+    grid_shape: OutArg[tuple]
+    total_simulations: OutArg[int]
+
+    def __init__(self):
+        self.__id__ = None
+        self.next = None
+        self.done = False
+        self.param1_values = InArg(None)
+        self.param2_values = InArg(None)
+        self.param1_name = InArg("param1")
+        self.param2_name = InArg("param2")
+        self.grid_combinations = OutArg(None)
+        self.param1_axis = OutArg(None)
+        self.param2_axis = OutArg(None)
+        self.grid_shape = OutArg(None)
+        self.total_simulations = OutArg(None)
+
+    def execute(self, ctx) -> None:
+        p1 = self.param1_values.value
+        p2 = self.param2_values.value
+
+        if p1 is None or len(p1) == 0:
+            raise ValueError(
+                "PSEParameterGrid: param1_values is empty or not connected. "
+                "Connect a PSELinspaceRange or PSEValueList component."
+            )
+        if p2 is None or len(p2) == 0:
+            raise ValueError(
+                "PSEParameterGrid: param2_values is empty or not connected. "
+                "Connect a PSELinspaceRange or PSEValueList component."
+            )
+
+        p1_name = self.param1_name.value or "param1"
+        p2_name = self.param2_name.value or "param2"
+
+        combinations = list(itertools.product(p1, p2))
+
+        self.grid_combinations.value = combinations
+        self.param1_axis.value = list(p1)
+        self.param2_axis.value = list(p2)
+        self.grid_shape.value = (len(p1), len(p2))
+        self.total_simulations.value = len(combinations)
+
+        ctx["pse_param1_name"] = p1_name
+        ctx["pse_param2_name"] = p2_name
+        ctx["pse_param1_axis"] = list(p1)
+        ctx["pse_param2_axis"] = list(p2)
+        ctx["pse_grid_shape"] = (len(p1), len(p2))
+
+        print(f"[PSEParameterGrid] Created {len(p1)}x{len(p2)} = "
+              f"{len(combinations)} combinations")
+        print(f"  {p1_name}: {p1[0]:.4f} -> {p1[-1]:.4f} ({len(p1)} points)")
+        print(f"  {p2_name}: {p2[0]:.4f} -> {p2[-1]:.4f} ({len(p2)} points)")

--- a/xai_components/xai_pse/metric_components.py
+++ b/xai_components/xai_pse/metric_components.py
@@ -1,0 +1,150 @@
+﻿# -*- coding: utf-8 -*-
+#
+# "TheVirtualBrain - Widgets" package
+#
+# (c) 2022-2025, TVB Widgets Team
+#
+
+import numpy
+from xai_components.base import Component, InArg, OutArg, xai_component
+
+
+@xai_component(color='rgb(38, 166, 154)')
+class PSEResultCollector(Component):
+    single_result: InArg[any]
+    accumulated: InArg[list]
+    accumulated_out: OutArg[list]
+    count: OutArg[int]
+
+    def __init__(self):
+        self.__id__ = None
+        self.next = None
+        self.done = False
+        self.single_result = InArg(None)
+        self.accumulated = InArg(None)
+        self.accumulated_out = OutArg(None)
+        self.count = OutArg(None)
+
+    def execute(self, ctx) -> None:
+        current_list = self.accumulated.value if self.accumulated.value is not None else []
+
+        new_result = self.single_result.value
+        if new_result is None:
+            raise ValueError(
+                "PSEResultCollector: single_result is None. "
+                "Ensure the Simulator component output is connected."
+            )
+
+        current_list.append(new_result)
+        self.accumulated_out.value = current_list
+        self.count.value = len(current_list)
+        print(f"[PSEResultCollector] Collected result #{len(current_list)}")
+
+
+@xai_component(color='rgb(38, 166, 154)')
+class PSEGlobalVariance(Component):
+    simulation_results: InArg[list]
+    grid_shape: InArg[tuple]
+    metric_values: OutArg[list]
+    metric_matrix: OutArg[any]
+    metric_name: OutArg[str]
+
+    def __init__(self):
+        self.__id__ = None
+        self.next = None
+        self.done = False
+        self.simulation_results = InArg(None)
+        self.grid_shape = InArg(None)
+        self.metric_values = OutArg(None)
+        self.metric_matrix = OutArg(None)
+        self.metric_name = OutArg(None)
+
+    def execute(self, ctx) -> None:
+        results = self.simulation_results.value
+        if results is None or len(results) == 0:
+            raise ValueError(
+                "PSEGlobalVariance: no simulation results provided. "
+                "Connect PSEResultCollector accumulated_out."
+            )
+
+        variances = []
+        for i, result in enumerate(results):
+            try:
+                ts = numpy.array(result) if not isinstance(result, numpy.ndarray) else result
+                variance = float(numpy.var(ts))
+                variances.append(variance)
+            except Exception as e:
+                print(f"[PSEGlobalVariance] Warning: could not compute "
+                      f"variance for result #{i}: {e}")
+                variances.append(float('nan'))
+
+        self.metric_values.value = variances
+        self.metric_name.value = "Global Variance"
+
+        shape = self.grid_shape.value
+        if shape is not None and len(shape) == 2:
+            expected = shape[0] * shape[1]
+            if len(variances) == expected:
+                self.metric_matrix.value = numpy.array(variances).reshape(shape)
+                print(f"[PSEGlobalVariance] Computed {shape[0]}x{shape[1]} "
+                      f"variance matrix")
+            else:
+                print(f"[PSEGlobalVariance] Warning: expected {expected} "
+                      f"results but got {len(variances)}, skipping reshape")
+                self.metric_matrix.value = numpy.array(variances)
+        else:
+            self.metric_matrix.value = numpy.array(variances)
+
+        print(f"[PSEGlobalVariance] Range: "
+              f"[{numpy.nanmin(variances):.6f}, {numpy.nanmax(variances):.6f}]")
+
+
+@xai_component(color='rgb(38, 166, 154)')
+class PSEVarianceOfVariance(Component):
+    simulation_results: InArg[list]
+    grid_shape: InArg[tuple]
+    metric_values: OutArg[list]
+    metric_matrix: OutArg[any]
+    metric_name: OutArg[str]
+
+    def __init__(self):
+        self.__id__ = None
+        self.next = None
+        self.done = False
+        self.simulation_results = InArg(None)
+        self.grid_shape = InArg(None)
+        self.metric_values = OutArg(None)
+        self.metric_matrix = OutArg(None)
+        self.metric_name = OutArg(None)
+
+    def execute(self, ctx) -> None:
+        results = self.simulation_results.value
+        if results is None or len(results) == 0:
+            raise ValueError(
+                "PSEVarianceOfVariance: no simulation results provided."
+            )
+
+        vov_values = []
+        for i, result in enumerate(results):
+            try:
+                ts = numpy.array(result) if not isinstance(result, numpy.ndarray) else result
+                if ts.ndim >= 3:
+                    var_per_region = numpy.var(ts, axis=0)
+                    vov = float(numpy.var(var_per_region))
+                else:
+                    vov = float(numpy.var(numpy.var(ts, axis=0)))
+                vov_values.append(vov)
+            except Exception as e:
+                print(f"[PSEVarianceOfVariance] Warning: result #{i}: {e}")
+                vov_values.append(float('nan'))
+
+        self.metric_values.value = vov_values
+        self.metric_name.value = "Variance of Variance"
+
+        shape = self.grid_shape.value
+        if shape and len(shape) == 2 and len(vov_values) == shape[0] * shape[1]:
+            self.metric_matrix.value = numpy.array(vov_values).reshape(shape)
+        else:
+            self.metric_matrix.value = numpy.array(vov_values)
+
+        print(f"[PSEVarianceOfVariance] Computed for {len(vov_values)} simulations")

--- a/xai_components/xai_pse/range_components.py
+++ b/xai_components/xai_pse/range_components.py
@@ -1,0 +1,116 @@
+﻿# -*- coding: utf-8 -*-
+#
+# "TheVirtualBrain - Widgets" package
+#
+# (c) 2022-2025, TVB Widgets Team
+#
+
+import numpy
+from xai_components.base import Component, InArg, OutArg, xai_component
+
+
+@xai_component(color='rgb(126, 87, 194)')
+class PSELinspaceRange(Component):
+    start: InArg[float]
+    stop: InArg[float]
+    num_points: InArg[int]
+    values: OutArg[list]
+
+    def __init__(self):
+        self.__id__ = None
+        self.next = None
+        self.done = False
+        self.start = InArg(0.0)
+        self.stop = InArg(1.0)
+        self.num_points = InArg(10)
+        self.values = OutArg(None)
+
+    def execute(self, ctx) -> None:
+        start_val = self.start.value if self.start.value is not None else 0.0
+        stop_val = self.stop.value if self.stop.value is not None else 1.0
+        n_points = self.num_points.value if self.num_points.value is not None else 10
+
+        if n_points < 1:
+            raise ValueError(
+                f"PSELinspaceRange: num_points must be >= 1, got {n_points}"
+            )
+        if start_val >= stop_val:
+            raise ValueError(
+                f"PSELinspaceRange: start ({start_val}) must be < stop ({stop_val})"
+            )
+
+        result = numpy.linspace(start_val, stop_val, n_points).tolist()
+        self.values.value = result
+        print(f"[PSELinspaceRange] Generated {len(result)} values: "
+              f"[{result[0]:.4f} ... {result[-1]:.4f}]")
+
+
+@xai_component(color='rgb(126, 87, 194)')
+class PSEArangeRange(Component):
+    start: InArg[float]
+    stop: InArg[float]
+    step: InArg[float]
+    values: OutArg[list]
+
+    def __init__(self):
+        self.__id__ = None
+        self.next = None
+        self.done = False
+        self.start = InArg(0.0)
+        self.stop = InArg(1.0)
+        self.step = InArg(0.1)
+        self.values = OutArg(None)
+
+    def execute(self, ctx) -> None:
+        start_val = self.start.value if self.start.value is not None else 0.0
+        stop_val = self.stop.value if self.stop.value is not None else 1.0
+        step_val = self.step.value if self.step.value is not None else 0.1
+
+        if step_val <= 0:
+            raise ValueError(
+                f"PSEArangeRange: step must be > 0, got {step_val}"
+            )
+        if start_val >= stop_val:
+            raise ValueError(
+                f"PSEArangeRange: start ({start_val}) must be < stop ({stop_val})"
+            )
+
+        result = numpy.arange(start_val, stop_val, step_val).tolist()
+        self.values.value = result
+        print(f"[PSEArangeRange] Generated {len(result)} values "
+              f"with step {step_val}")
+
+
+@xai_component(color='rgb(126, 87, 194)')
+class PSEValueList(Component):
+    values_string: InArg[str]
+    values: OutArg[list]
+
+    def __init__(self):
+        self.__id__ = None
+        self.next = None
+        self.done = False
+        self.values_string = InArg(None)
+        self.values = OutArg(None)
+
+    def execute(self, ctx) -> None:
+        raw = self.values_string.value
+        if raw is None or raw.strip() == "":
+            raise ValueError(
+                "PSEValueList: values_string cannot be empty. "
+                "Provide comma-separated floats, e.g. '0.1, 0.5, 1.0'"
+            )
+
+        try:
+            result = [float(v.strip()) for v in raw.split(",")]
+        except ValueError as e:
+            raise ValueError(
+                f"PSEValueList: could not parse '{raw}' as comma-separated "
+                f"floats. Error: {e}"
+            )
+
+        if len(result) == 0:
+            raise ValueError("PSEValueList: parsed an empty list")
+
+        self.values.value = result
+        print(f"[PSEValueList] Loaded {len(result)} custom values: {result}")


### PR DESCRIPTION
# Description

This PR adds a new `xai_pse` component library that brings parameter space
exploration (PSE) capabilities to the Xircuits canvas.

Right now, if you want to explore how a TVB simulation behaves across different
parameter values, you have to manually change Literal inputs and re-run each
time. That's tedious and error-prone, especially for 2D sweeps where the number
of combinations grows quickly.

These components solve that by letting users define ranges, build grids, collect
results, and compute metrics — all as draggable nodes on the canvas, wired
together with the existing ForEach loops and Simulator.

I built this after reading through the PSE widget in tvb-widgets and the
ParallelSimulations example, following the patterns already used by components
like Generic2dOscillator and Simulator.

## What's included

**Range components** (replace static Literal inputs):
- `PSELinspaceRange` — generates N evenly spaced values
- `PSEArangeRange` — generates values with a fixed step size
- `PSEValueList` — parses a comma-separated string of custom values

**Grid component** (replaces nested ForEach loops):
- `PSEParameterGrid` — takes two ranges and outputs every combination

**Metric components** (analyze sweep results):
- `PSEResultCollector` — accumulates simulation outputs inside a loop
- `PSEGlobalVariance` — computes variance per simulation for heatmaps
- `PSEVarianceOfVariance` — finds regimes where brain regions behave differently

All range outputs are Python lists so they plug directly into existing ForEach
loop components. Metric components can reshape results into 2D matrices matching
the grid shape, ready for heatmap visualization.

## References

- GSoC 2026 Project #12 discussion on Neurostars, where @liadomide noted that
  Literal inputs are not enough for PSE and Range + Loop components are needed
- tvb-widgets PSE widget: `tvb-widgets/tvbwidgets/ui/pse_widget.py`
- Parallel simulations example: `examples/ParallelSimulations.xircuits`

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [x] Xircuits Component Library
- [ ] Xircuits Project Template
- [x] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

35 pytest test cases covering all 7 components. Each component has tests for
normal operation, edge cases, and input validation.

**1. Run the full test suite**

    1. `pip install -e .[full]`
    2. `python -m pytest tests/test_pse_components.py -v`
    3. All 35 tests should pass

**2. Verify imports work**

    1. `python -c "from xai_components.xai_pse import PSELinspaceRange, PSEParameterGrid, PSEGlobalVariance; print('OK')"`

**3. Verify existing components are not affected**

    1. `python -c "from xai_components.xai_tvb_models.oscillator import Generic2dOscillator; g = Generic2dOscillator(); print('OK')"`

**Test coverage includes:**
- Range generation with correct values and counts
- Default value handling when inputs are None
- Input validation (negative steps, empty lists, invalid CSV strings)
- Output type verification (Python list, not numpy array)
- Grid Cartesian product correctness and shape
- Context metadata population for downstream components
- Metric computation correctness (zero variance, heterogeneous signals)
- Matrix reshape matching grid dimensions

**Tested on? Specify Version.**

- [x] Windows
- [ ] Linux
- [ ] Mac
- [ ] Others

Python 3.14.0, pytest 9.0.2

# Notes

- No existing files were modified — this PR only adds new files
- The `__init__` pattern avoids `super().__init__()` to stay compatible with
  Python 3.13+ where `self.__annotations__` behavior changed. This matches how
  existing TVB components like Generic2dOscillator handle initialization.
- Components use `numpy` (not `np`) to match the import convention used
  throughout the existing TVB component files.

### Files added

xai_components/xai_pse/
├── init.py
├── range_components.py # PSELinspaceRange, PSEArangeRange, PSEValueList
├── grid_components.py # PSEParameterGrid
└── metric_components.py # PSEResultCollector, PSEGlobalVariance, PSEVarianceOfVariance
tests/
└── test_pse_components.py # 35 test cases